### PR TITLE
[58612] If no entitlement available, then ...

### DIFF
--- a/FoDUploader/API/Errors.cs
+++ b/FoDUploader/API/Errors.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FoDUploader.API
+{
+    /// <summary>
+    /// Error Response
+    /// </summary>
+    public class ErrorResponse
+    {
+        /// <summary>
+        /// List of errors
+        /// </summary>
+        public List<ErrorDTO> Errors { get; set; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public ErrorResponse()
+        {
+            Errors = new List<ErrorDTO>();
+        }
+    }
+
+    /// <summary>
+    /// Error
+    /// </summary>
+    public class ErrorDTO
+    {
+        /// <summary>
+        /// The error code
+        /// </summary>
+        public int? ErrorCode { get; set; }
+
+        /// <summary>
+        /// The error message
+        /// </summary>
+        public string Message { get; set; }
+    }
+}

--- a/FoDUploader/FoDUploader.csproj
+++ b/FoDUploader/FoDUploader.csproj
@@ -79,6 +79,7 @@
   <ItemGroup>
     <Compile Include="API\AssessmentTypes.cs" />
     <Compile Include="API\AuthorizationResponse.cs" />
+    <Compile Include="API\Errors.cs" />
     <Compile Include="API\Features.cs" />
     <Compile Include="API\Release.cs" />
     <Compile Include="API\TenantEntitlements.cs" />


### PR DESCRIPTION
... then create a negative entitlement single scan (if allowed for that
tenant).

Part of a User Story from 4.3.

1.) Created Error object to parse errors directly from api,
2.) Attempt a start scan even without entitlements (api will return 400 if unavailable),
3.) exit loop on Bad Request to prevent the "POST exceeded" error