### PR TITLE
Do not hold console open

### DIFF
--- a/FoDUploader/Program.cs
+++ b/FoDUploader/Program.cs
@@ -190,13 +190,6 @@ namespace FoDUploader
 
             api.RetireToken();
 
-            // hold console open - ask around if this is something we want to do for interactive runs? Feedback has been conflicting regarding this behavior.
-
-            if (_isConsole)
-            {
-                Console.WriteLine("Press any key to exit...");
-                Console.ReadKey();
-            }
         }
 
         #region Display Information


### PR DESCRIPTION
Holding the console open makes scripting this tool inside a CI/CD pipeline difficult.